### PR TITLE
Update link to hierarchical edge bundling block

### DIFF
--- a/bundle.html
+++ b/bundle.html
@@ -134,7 +134,7 @@ $(function(){
     <p>A few blocks with more complicated codes to showcase what's possible to do with hierarchical edge bundling.</a>
     <div id="portfolio-items" class="row">
       <div class="col-md-4 col-sm-6 portfolio-item">
-        <a class="portfolio-link" href="https://bl.ocks.org/d3noob/06e72deea99e7b4859841f305f63ba85">
+        <a class="portfolio-link" href="https://bl.ocks.org/mbostock/1044242">
           <div class="portfolio-hover">
             <div class="portfolio-hover-content">
               <p>Application to the flare dataset</p>


### PR DESCRIPTION
The [previous link](https://bl.ocks.org/d3noob/06e72deea99e7b4859841f305f63ba85) pointed to a sankey diagram. I believe [this is](https://bl.ocks.org/mbostock/1044242) the block the screenshot was meant to match.