### PR TITLE
Load the base D3 library using HTTPS

### DIFF
--- a/DOC/reference.html
+++ b/DOC/reference.html
@@ -246,7 +246,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/basic/html.html
+++ b/basic/html.html
@@ -35,7 +35,7 @@
     <link href="../LIB/prism.css" rel="stylesheet" />
 
     <!-- D3.JS v4 -->
-    <script src="http://d3js.org/d3.v4.js"></script>
+    <script src="https://d3js.org/d3.v4.js"></script>
     
     <!-- JQUERY -->
     <script src="../vendor/jquery/jquery.min.js"></script> 
@@ -152,7 +152,7 @@
 
 <!-- Add a line of text -->
 <p id="mytext">Hello world!</p>
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->

--- a/basic/margin.html
+++ b/basic/margin.html
@@ -166,7 +166,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place. Give it a red border -->
 <div id="my_dataviz" style="border: solid; border-width: 2px; border-color: red"></div>  

--- a/basic/split_screen.html
+++ b/basic/split_screen.html
@@ -161,7 +161,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place. Give it a red border -->
 <div id="my_dataviz" style="border: solid; border-width: 2px; border-color: red"></div>  

--- a/basic/zoom.html
+++ b/basic/zoom.html
@@ -166,7 +166,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place. Give it a red border -->
 <center><div id="my_dataviz"></div></center>

--- a/function/d3.arc.html
+++ b/function/d3.arc.html
@@ -158,7 +158,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=110></svg>  
@@ -253,7 +253,7 @@ document.getElementById('code').addEventListener("input", function() {
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=110 id="my_dataviz"></svg>  

--- a/function/d3.area.html
+++ b/function/d3.area.html
@@ -158,7 +158,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=110></svg>  
@@ -252,7 +252,7 @@ document.getElementById('code').addEventListener("input", function() {
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=110 id="my_dataviz"></svg>  

--- a/function/d3.line.html
+++ b/function/d3.line.html
@@ -158,7 +158,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=100></svg>  
@@ -252,7 +252,7 @@ document.getElementById('code').addEventListener("input", function() {
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=100 id="my_dataviz"></svg>  

--- a/function/d3.ribbon.html
+++ b/function/d3.ribbon.html
@@ -158,7 +158,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=300></svg>  
@@ -253,7 +253,7 @@ document.getElementById('code').addEventListener("input", function() {
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width=1000 height=300 id="my_dataviz"></svg>  

--- a/graph/0_template.html
+++ b/graph/0_template.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/arc_basic.html
+++ b/graph/arc_basic.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/arc_highlight.html
+++ b/graph/arc_highlight.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/arc_template.html
+++ b/graph/arc_template.html
@@ -165,7 +165,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load color palette -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/arc_vertical.html
+++ b/graph/arc_vertical.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/area_basic.html
+++ b/graph/area_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/area_brushZoom.html
+++ b/graph/area_brushZoom.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/area_lineDot.html
+++ b/graph/area_lineDot.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/area_smallmultiple.html
+++ b/graph/area_smallmultiple.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/backgroundmap_basic.html
+++ b/graph/backgroundmap_basic.html
@@ -173,7 +173,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/backgroundmap_changeprojection.html
+++ b/graph/backgroundmap_changeprojection.html
@@ -176,7 +176,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/backgroundmap_country.html
+++ b/graph/backgroundmap_country.html
@@ -173,7 +173,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/barplot_animation_start.html
+++ b/graph/barplot_animation_start.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_basic.html
+++ b/graph/barplot_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_button_color.html
+++ b/graph/barplot_button_color.html
@@ -175,7 +175,7 @@ function changeColor(color){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="changeColor('blue')">Get blue</button>

--- a/graph/barplot_button_data_csv.html
+++ b/graph/barplot_button_data_csv.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="update('var1')">Variable 1</button>

--- a/graph/barplot_button_data_hard.html
+++ b/graph/barplot_button_data_hard.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="update(data1)">Variable 1</button>

--- a/graph/barplot_button_data_simple.html
+++ b/graph/barplot_button_data_simple.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="update(data1)">Variable 1</button>

--- a/graph/barplot_grouped_basicWide.html
+++ b/graph/barplot_grouped_basicWide.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_horizontal.html
+++ b/graph/barplot_horizontal.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_ordered.html
+++ b/graph/barplot_ordered.html
@@ -162,7 +162,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_stacked_basicLong.html
+++ b/graph/barplot_stacked_basicLong.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_stacked_basicWide.html
+++ b/graph/barplot_stacked_basicWide.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_stacked_highlight.html
+++ b/graph/barplot_stacked_highlight.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js & color palette-->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/barplot_stacked_hover.html
+++ b/graph/barplot_stacked_hover.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/barplot_stacked_percent.html
+++ b/graph/barplot_stacked_percent.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/beeswarm_basic.html
+++ b/graph/beeswarm_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/boxplot_basic.html
+++ b/graph/boxplot_basic.html
@@ -176,7 +176,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/boxplot_horizontal.html
+++ b/graph/boxplot_horizontal.html
@@ -176,7 +176,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/boxplot_several_groups.html
+++ b/graph/boxplot_several_groups.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/boxplot_show_individual_points.html
+++ b/graph/boxplot_show_individual_points.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/bubble_basic.html
+++ b/graph/bubble_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/bubble_color.html
+++ b/graph/bubble_color.html
@@ -165,7 +165,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load color scale -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/bubble_legend.html
+++ b/graph/bubble_legend.html
@@ -162,7 +162,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/bubble_template.html
+++ b/graph/bubble_template.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load color scale -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/bubble_tooltip.html
+++ b/graph/bubble_tooltip.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load color scale -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/bubblemap_basic.html
+++ b/graph/bubblemap_basic.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
 <!-- Create an element where the map will take place -->

--- a/graph/bubblemap_buttonControl.html
+++ b/graph/bubblemap_buttonControl.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
 <!-- Button -->

--- a/graph/bubblemap_circleFeatures.html
+++ b/graph/bubblemap_circleFeatures.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
 <!-- Create an element where the map will take place -->

--- a/graph/bubblemap_leaflet_basic.html
+++ b/graph/bubblemap_leaflet_basic.html
@@ -174,7 +174,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
 <!-- Load Leaflet -->

--- a/graph/bubblemap_template.html
+++ b/graph/bubblemap_template.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 

--- a/graph/bubblemap_tooltip.html
+++ b/graph/bubblemap_tooltip.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and the geo projection plugin -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
 <!-- Create an element where the map will take place -->

--- a/graph/chord_axis_labels.html
+++ b/graph/chord_axis_labels.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/chord_basic.html
+++ b/graph/chord_basic.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/chord_colors.html
+++ b/graph/chord_colors.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/chord_interactive.html
+++ b/graph/chord_interactive.html
@@ -155,7 +155,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/choropleth_basic.html
+++ b/graph/choropleth_basic.html
@@ -173,7 +173,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/circular_barplot_animation_start.html
+++ b/graph/circular_barplot_animation_start.html
@@ -158,7 +158,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/circular_barplot_basic.html
+++ b/graph/circular_barplot_basic.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Function for radial charts -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3-scale-radial.js"></script>

--- a/graph/circular_barplot_double.html
+++ b/graph/circular_barplot_double.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Function for radial charts -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3-scale-radial.js"></script>

--- a/graph/circular_barplot_label.html
+++ b/graph/circular_barplot_label.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Function for radial charts -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3-scale-radial.js"></script>

--- a/graph/circular_barplot_template.html
+++ b/graph/circular_barplot_template.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Function for radial charts -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3-scale-radial.js"></script>

--- a/graph/circularpacking_basic.html
+++ b/graph/circularpacking_basic.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/circularpacking_drag.html
+++ b/graph/circularpacking_drag.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/circularpacking_group.html
+++ b/graph/circularpacking_group.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/circularpacking_template.html
+++ b/graph/circularpacking_template.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Color palette -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/connectedscatter_basic.html
+++ b/graph/connectedscatter_basic.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/connectedscatter_legend.html
+++ b/graph/connectedscatter_legend.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/connectedscatter_multi.html
+++ b/graph/connectedscatter_multi.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/connectedscatter_select.html
+++ b/graph/connectedscatter_select.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Initialize a select button -->
 <select id="selectButton"></select>

--- a/graph/connectedscatter_tooltip.html
+++ b/graph/connectedscatter_tooltip.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/connectionmap_basic.html
+++ b/graph/connectionmap_basic.html
@@ -39,7 +39,7 @@
   <link href="../LIB/prism.css" rel="stylesheet" />
 
   <!-- Load d3.js -->
-  <script src="http://d3js.org/d3.v4.js"></script>
+  <script src="https://d3js.org/d3.v4.js"></script>
   <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
   <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/connectionmap_csv.html
+++ b/graph/connectionmap_csv.html
@@ -39,7 +39,7 @@
   <link href="../LIB/prism.css" rel="stylesheet" />
 
   <!-- Load d3.js -->
-  <script src="http://d3js.org/d3.v4.js"></script>
+  <script src="https://d3js.org/d3.v4.js"></script>
   <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
   <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/connectionmap_multi.html
+++ b/graph/connectionmap_multi.html
@@ -39,7 +39,7 @@
   <link href="../LIB/prism.css" rel="stylesheet" />
 
   <!-- Load d3.js -->
-  <script src="http://d3js.org/d3.v4.js"></script>
+  <script src="https://d3js.org/d3.v4.js"></script>
   <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
   <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/correlogram_basic.html
+++ b/graph/correlogram_basic.html
@@ -167,7 +167,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/correlogram_histo.html
+++ b/graph/correlogram_histo.html
@@ -165,7 +165,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/correlogram_scatter.html
+++ b/graph/correlogram_scatter.html
@@ -167,7 +167,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/custom_annotation.html
+++ b/graph/custom_annotation.html
@@ -190,7 +190,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load d3-annotation -->
 <script src="https://rawgit.com/susielu/d3-annotation/master/d3-annotation.min.js"></script>
@@ -323,7 +323,7 @@ myJSParser('js-sectionA', 'res-sectionA');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load d3-annotation -->
 <script src="https://rawgit.com/susielu/d3-annotation/master/d3-annotation.min.js"></script>
@@ -458,7 +458,7 @@ myJSParser('js-sectionB', 'res-sectionB');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width="460" height="400" id="example3"></div>
@@ -639,7 +639,7 @@ myJSParser('js-sectionC', 'res-sectionC');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <svg width="460" height="400" id="example4"></div>

--- a/graph/custom_legend.html
+++ b/graph/custom_legend.html
@@ -201,7 +201,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div>
@@ -319,7 +319,7 @@ myJSParser('js-sectionA', 'res-sectionA');
 <meta charset="utf-8">
 
 <!-- Load d3.js & color palette -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->
@@ -457,7 +457,7 @@ myJSParser('js-sectionB', 'res-sectionB');
 <meta charset="utf-8">
 
 <!-- Load d3.js & color palette -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/custom_responsive.html
+++ b/graph/custom_responsive.html
@@ -176,7 +176,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="div_basicResize"></div>

--- a/graph/custom_theme.html
+++ b/graph/custom_theme.html
@@ -187,7 +187,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>
@@ -375,7 +375,7 @@ myJSParser('js-sectionA', 'res-sectionA');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz2"></div>
@@ -554,7 +554,7 @@ myJSParser('js-sectionB', 'res-sectionB');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz3"></div>
@@ -748,7 +748,7 @@ myJSParser('js-sectionC', 'res-sectionC');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz4"></div>

--- a/graph/dendrogram_basic.html
+++ b/graph/dendrogram_basic.html
@@ -180,7 +180,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/dendrogram_radial_basic.html
+++ b/graph/dendrogram_radial_basic.html
@@ -177,7 +177,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/density2d_contour.html
+++ b/graph/density2d_contour.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- specific plugin -->
 <script src="https://d3js.org/d3-contour.v1.min.js"></script>

--- a/graph/density2d_hexbin.html
+++ b/graph/density2d_hexbin.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- specific plugin -->
 <script src="https://d3js.org/d3-hexbin.v0.2.min.js"></script>

--- a/graph/density2d_histogram2d.html
+++ b/graph/density2d_histogram2d.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- specific plugin -->
 <script src="https://cdn.rawgit.com/fabid/d3-rectbin/master/rectbin.js"></script>

--- a/graph/density2d_shading.html
+++ b/graph/density2d_shading.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- specific plugin -->
 <script src="https://d3js.org/d3-contour.v1.min.js"></script>

--- a/graph/density_basic.html
+++ b/graph/density_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/density_double.html
+++ b/graph/density_double.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/density_filter.html
+++ b/graph/density_filter.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Initialize a select button -->
 <select id="selectButton"></select>

--- a/graph/density_mirror.html
+++ b/graph/density_mirror.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/density_slider.html
+++ b/graph/density_slider.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add a slider -->
 <input type="range" name="mySlider" id=mySlider min="10" max="100" value="50">

--- a/graph/donut_basic.html
+++ b/graph/donut_basic.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/donut_label.html
+++ b/graph/donut_label.html
@@ -177,7 +177,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js & color scale -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/heatmap_basic.html
+++ b/graph/heatmap_basic.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/heatmap_style.html
+++ b/graph/heatmap_style.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/heatmap_tooltip.html
+++ b/graph/heatmap_tooltip.html
@@ -170,7 +170,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/hexbinmap_geo_basic.html
+++ b/graph/hexbinmap_geo_basic.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/hexbinmap_geo_label.html
+++ b/graph/hexbinmap_geo_label.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 <script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
 

--- a/graph/histogram_basic.html
+++ b/graph/histogram_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/histogram_binSize.html
+++ b/graph/histogram_binSize.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/histogram_coloredTail.html
+++ b/graph/histogram_coloredTail.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/histogram_double.html
+++ b/graph/histogram_double.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/histogram_tooltip.html
+++ b/graph/histogram_tooltip.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/interactivity_brush.html
+++ b/graph/interactivity_brush.html
@@ -188,7 +188,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <svg width=400 height=400 id="dataviz_brushing"></svg>
@@ -304,7 +304,7 @@ myJSParser('js-basicBrush', 'res-basicBrush');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <svg width=400 height=400 id="dataviz_brushing1D"></svg>
@@ -432,7 +432,7 @@ myJSParser('js-basicBrush1D', 'res-basicBrush1D');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <svg width=300 height=300 id="dataviz_brushChange"></svg>
@@ -569,7 +569,7 @@ myJSParser('js-brushChange', 'res-brushChange');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <svg width=300 height=300 id="dataviz_brushCSS"></svg>
@@ -710,7 +710,7 @@ myJSParser('js-brushCSS', 'res-brushCSS');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_brushScatter"></div>
@@ -900,7 +900,7 @@ myJSParser('js-brushScatter', 'res-brushScatter');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_brushZoom"></div>

--- a/graph/interactivity_button.html
+++ b/graph/interactivity_button.html
@@ -302,7 +302,7 @@ document.getElementById('code-allType').addEventListener("input", function() {
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons-->
 <button type="button" onclick="changeColor('blue')">Blue</button>
@@ -420,7 +420,7 @@ myJSParser('js-basicTrigger', 'res-basicTrigger');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add  button-->
 <input type="number" id="buttonSize" value=13>
@@ -546,7 +546,7 @@ myJSParser('js-basicEventListener', 'res-basicEventListener');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_builtWithD3"></div>
@@ -912,7 +912,7 @@ myJSParser('js-buttonStyle', 'res-buttonStyle');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create the radio button -->
 <div id="colorButton">
@@ -1050,7 +1050,7 @@ myJSParser('js-delay', 'res-delay');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create the radio button -->
 <input type="range" name="mySlider" id=mySlider min="2" max="40" value="10">

--- a/graph/interactivity_tooltip.html
+++ b/graph/interactivity_tooltip.html
@@ -190,7 +190,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>
@@ -319,7 +319,7 @@ myJSParser('js-basicTrigger', 'res-basicTrigger');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="div_customContent"></div>
@@ -514,7 +514,7 @@ myJSParser('js-customContent', 'res-customContent');
 <meta charset="utf-8">
 
 <!-- Load d3.js & plugin-->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/interactivity_transition.html
+++ b/graph/interactivity_transition.html
@@ -216,7 +216,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div with just a rect in svg -->
 <div>
@@ -331,7 +331,7 @@ myJSParser('js-mostBasic', 'res-mostBasic');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a button to trigger the transition -->
 <button onclick="triggerTransition()">Trigger transition</button>
@@ -444,7 +444,7 @@ myJSParser('js-button', 'res-button');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a button to trigger the transition -->
 <button onclick="triggerTransitionPiping()">Trigger transition</button>
@@ -579,7 +579,7 @@ myJSParser('js-piping', 'res-piping');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a button to trigger the transition -->
 <button onclick="triggerTransitionDelay()">Trigger transition</button>
@@ -708,7 +708,7 @@ myJSParser('js-delay', 'res-delay');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a button to trigger the transition -->
 <button onclick="triggerTransitionAxis()">Trigger transition</button>
@@ -846,7 +846,7 @@ myJSParser('js-axis', 'res-axis');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a data1 to trigger the transition -->
 <button onclick="triggerTransition()">Trigger transition</button>
@@ -993,7 +993,7 @@ myJSParser('js-data1', 'res-data1');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a data2 to trigger the transition -->
 <button onclick="triggerTransitionData2()">Trigger transition</button>
@@ -1129,7 +1129,7 @@ myJSParser('js-data2', 'res-data2');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a data3 to trigger the transition -->
 <button onclick="triggerTransitionData3()">Trigger transition</button>

--- a/graph/interactivity_zoom.html
+++ b/graph/interactivity_zoom.html
@@ -185,7 +185,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_basicZoom"></div>
@@ -316,7 +316,7 @@ myJSParser('js-basicZoom', 'res-basicZoom');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_axisZoom"></div>
@@ -530,7 +530,7 @@ myJSParser('js-axisZoom', 'res-axisZoom');
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the circle will take place -->
 <div id="dataviz_brushZoom"></div>

--- a/graph/line_basic.html
+++ b/graph/line_basic.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/line_brushZoom.html
+++ b/graph/line_brushZoom.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/line_change_data.html
+++ b/graph/line_change_data.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="update(data1)">Dataset 1</button>

--- a/graph/line_confidence_interval.html
+++ b/graph/line_confidence_interval.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/line_cursor.html
+++ b/graph/line_cursor.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/line_filter.html
+++ b/graph/line_filter.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Initialize a select button -->
 <select id="selectButton"></select>

--- a/graph/line_select.html
+++ b/graph/line_select.html
@@ -169,7 +169,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Initialize a select button -->
 <select id="selectButton"></select>

--- a/graph/line_several_group.html
+++ b/graph/line_several_group.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/line_smallmultiple.html
+++ b/graph/line_smallmultiple.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/lollipop_animationStart.html
+++ b/graph/lollipop_animationStart.html
@@ -163,7 +163,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/lollipop_basic.html
+++ b/graph/lollipop_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/lollipop_button_data_csv.html
+++ b/graph/lollipop_button_data_csv.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Add 2 buttons -->
 <button onclick="update('var1')">Variable 1</button>

--- a/graph/lollipop_cleveland.html
+++ b/graph/lollipop_cleveland.html
@@ -162,7 +162,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/lollipop_horizontal.html
+++ b/graph/lollipop_horizontal.html
@@ -162,7 +162,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/lollipop_ordered.html
+++ b/graph/lollipop_ordered.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/network_animationStart.html
+++ b/graph/network_animationStart.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/network_basic.html
+++ b/graph/network_basic.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/network_test.html
+++ b/graph/network_test.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/parallel_basic.html
+++ b/graph/parallel_basic.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/parallel_custom.html
+++ b/graph/parallel_custom.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/parallel_selection.html
+++ b/graph/parallel_selection.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/pie_annotation.html
+++ b/graph/pie_annotation.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/pie_basic.html
+++ b/graph/pie_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/pie_changeData.html
+++ b/graph/pie_changeData.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Color scale -->
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>

--- a/graph/ridgeline_animation.html
+++ b/graph/ridgeline_animation.html
@@ -163,7 +163,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/ridgeline_basic.html
+++ b/graph/ridgeline_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/ridgeline_template.html
+++ b/graph/ridgeline_template.html
@@ -165,7 +165,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_animation_start.html
+++ b/graph/scatter_animation_start.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_basic.html
+++ b/graph/scatter_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_buttonXlim.html
+++ b/graph/scatter_buttonXlim.html
@@ -169,7 +169,7 @@ $(function(){
 <input type="number" id="buttonXlim" value=9>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_canvas.html
+++ b/graph/scatter_canvas.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_grouped.html
+++ b/graph/scatter_grouped.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_grouped_highlight.html
+++ b/graph/scatter_grouped_highlight.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/scatter_tooltip.html
+++ b/graph/scatter_tooltip.html
@@ -162,7 +162,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/stackedarea_basic.html
+++ b/graph/stackedarea_basic.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/stackedarea_template.html
+++ b/graph/stackedarea_template.html
@@ -167,7 +167,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js & color scale-->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/stackedarea_wideinput.html
+++ b/graph/stackedarea_wideinput.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/streamgraph_basic.html
+++ b/graph/streamgraph_basic.html
@@ -166,7 +166,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/streamgraph_template.html
+++ b/graph/streamgraph_template.html
@@ -165,7 +165,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js & color scale-->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/treemap_basic.html
+++ b/graph/treemap_basic.html
@@ -163,7 +163,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/treemap_custom.html
+++ b/graph/treemap_custom.html
@@ -163,7 +163,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/treemap_json.html
+++ b/graph/treemap_json.html
@@ -159,7 +159,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/upset_basic.html
+++ b/graph/upset_basic.html
@@ -155,7 +155,7 @@
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz" style="border: solid; border-width: 1px"></div>

--- a/graph/violin_basicDens.html
+++ b/graph/violin_basicDens.html
@@ -164,7 +164,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/violin_basicHist.html
+++ b/graph/violin_basicHist.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/violin_buttonLog.html
+++ b/graph/violin_buttonLog.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Create a div where the graph will take place -->
 <div id="my_dataviz"></div>

--- a/graph/violin_jitter.html
+++ b/graph/violin_jitter.html
@@ -165,7 +165,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js and plugin for color scale -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
 
 <!-- Create a div where the graph will take place -->

--- a/graph/wordcloud_basic.html
+++ b/graph/wordcloud_basic.html
@@ -171,7 +171,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load d3-cloud -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3.layout.cloud.js"></script>

--- a/graph/wordcloud_custom.html
+++ b/graph/wordcloud_custom.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load d3-cloud -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3.layout.cloud.js"></script>

--- a/graph/wordcloud_size.html
+++ b/graph/wordcloud_size.html
@@ -168,7 +168,7 @@ $(function(){
 <meta charset="utf-8">
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 <!-- Load d3-cloud -->
 <script src="https://cdn.jsdelivr.net/gh/holtzy/D3-graph-gallery@master/LIB/d3.layout.cloud.js"></script>

--- a/intro_d3js.html
+++ b/intro_d3js.html
@@ -436,7 +436,7 @@ document.getElementById('code-svg').addEventListener("input", function() {
 </svg>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->
@@ -564,7 +564,7 @@ myJSParser('js-basicTrigger', 'res-basicTrigger');
 <svg id="dataviz_area" height=200 width=450></svg>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->
@@ -672,7 +672,7 @@ myJSParser('js-coord', 'res-coord');
 <svg id="viz_area" height=200 width=450></svg>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->
@@ -789,7 +789,7 @@ myJSParser('js-scale', 'res-scale');
 <svg id="Viz_area" height=200 width=450></svg>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->
@@ -905,7 +905,7 @@ myJSParser('js-axis', 'res-axis');
 <div id="Area"></div>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->
@@ -1054,7 +1054,7 @@ myJSParser('js-margin', 'res-margin');
 <div id="scatter_area"></div>
 
 <!-- Load d3.js -->
-<script src="http://d3js.org/d3.v4.js"></script>
+<script src="https://d3js.org/d3.v4.js"></script>
 
 </xmp></code></pre>
 <!-- ==================================== -->


### PR DESCRIPTION
Loading failed on some pages due to using mixed content (HTTP and HTTPS).  This uses HTTPS to load all of the D3 library scripts so that we don't have to worry about accessing the page over HTTPS failing out sometimes.

Another option would've been to use //d3js.org/d3.v4.js instead of https://d3js.org/d3.v4.js and let the browser use the protocol the page initially loaded with to fix this.