### PR TITLE
FIX #28 UNNECESSARY TRANSFORM

### DIFF
--- a/graph/interactivity_zoom.html
+++ b/graph/interactivity_zoom.html
@@ -406,7 +406,6 @@ d3.csv("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/ir
       .attr("height", height)
       .style("fill", "none")
       .style("pointer-events", "all")
-      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
       .call(zoom);
   // now the user can zoom and it will trigger the function called updateChart
 


### PR DESCRIPTION
## What?
Fix #28 Unnecessary translate in zoom and pan example.
The "translate" attribute is not only unnecessary, it actually move the event zone away from the graph.
## Why?
Resolve issue #28 
## How?
Remove the unnecessary "transform" attribute
## Screenshots
Before:<img width="1376" alt="Screenshot 2020-10-01 at 22 15 56" src="https://user-images.githubusercontent.com/16229469/94858810-e5317900-0433-11eb-8220-1654da22f895.png">
After:<img width="1374" alt="Screenshot 2020-10-01 at 22 16 41" src="https://user-images.githubusercontent.com/16229469/94858851-f24e6800-0433-11eb-99a6-5cb30c6190b6.png">

