### PR TITLE
FIX #4 : WRONG DOCUMENTATION

### DIFF
--- a/graph/custom_color.html
+++ b/graph/custom_color.html
@@ -275,7 +275,7 @@ document.getElementById('code_divContinuous').addEventListener("input", function
 <p></p>
 <p>You have a several groups, and want to attribute a specific color to each group. Several way to build this scale</p>
 <ul>
-  <li>Give 2 colors as a range. Use <code>scaleLinear()</code></li>
+  <li>Give a list of colors as a range. Use <code>scaleOrdinal()</code></li>
   <li>Use a palette coming from ColorBrewer. Use <code>scaleSequential()</code>. List of available palette <a href="https://www.r-graph-gallery.com/38-rcolorbrewers-palettes/">here</a>. These color scale are offered in the <a href="https://github.com/d3/d3-scale-chromatic">d3-scale-chromatic plugin</a></li>
   <li>Palette coming from viridis. Same idea.</li>
 </ul>


### PR DESCRIPTION
## What?
Documentation changed to correspond to the "Categorical color scale" example.
## Why?
FIX #4 