### PR TITLE
Add missing documentation on tooltip styles

### DIFF
--- a/bubble.html
+++ b/bubble.html
@@ -328,6 +328,8 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
       .style("border-radius", "5px")
       .style("padding", "10px")
       .style("color", "white")
+      .style("z-index", "1070")
+      .style("position", "absolute")
 
   // -2- Create 3 functions to show / update (when mouse move but stay on same circle) / hide the tooltip
   var showTooltip = function(d) {

--- a/bubble.html
+++ b/bubble.html
@@ -321,6 +321,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
 
   // -1- Create a tooltip div that is hidden by default:
   var tooltip = d3.select("#my_dataviz")
+    .style("position", "relative")
     .append("div")
       .style("opacity", 0)
       .attr("class", "tooltip")


### PR DESCRIPTION
Without these 2 lines, the code shown is not enough to create the demonstrated tooltip. I had to use the developer tools in order to find out which additional styles were missing from the tooltip in my project. Therefore, I propose to add these 2 lines in order to document the required properties. 

Alternatively, one could add them in the css part.

See also: https://github.com/holtzy/D3-graph-gallery/issues/36