### PR TITLE
shape.html: fix external documentation link

### DIFF
--- a/graph/shape.html
+++ b/graph/shape.html
@@ -582,7 +582,7 @@ svg.append('path')
           In pure <code>svg</code>, an area would also been drawn using a
           <code>path</code> element. You can learn more about the obscure syntax
           of the <code>d</code> argument
-          <a href="https://www.w3schools.com/graphics/svg_path.asp">here</a>.
+          <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d">here</a>.
         </p>
         <pre
           class="language-html"

--- a/graph/shape.html
+++ b/graph/shape.html
@@ -446,7 +446,7 @@ svg.append('text')
           Here is how a line would be drawn in pure <code>svg</code>, using a
           <code>path</code> element. You can learn more about the obscure syntax
           of the <code>d</code> argument
-          <a href="https://www.w3schools.com/graphics/svg_path.asp">here</a>.
+          <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d">here</a>.
         </p>
         <pre
           class="language-html"


### PR DESCRIPTION
There is zero explanation of SVG Path element's ```d``` parameter on the w3schools page. Moz docs go into great detail about the ```d```.