### PR TITLE
add position:absolute style to tooltip example code

### DIFF
--- a/graph/heatmap_tooltip.html
+++ b/graph/heatmap_tooltip.html
@@ -333,6 +333,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/he
     .style("border-width", "2px")
     .style("border-radius", "5px")
     .style("padding", "5px")
+    .style("position", "absolute")
 
   // Three function that change the tooltip when user hover / move / leave a cell
   var mouseover = function(d) {
@@ -423,6 +424,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/he
     .style("border-width", "2px")
     .style("border-radius", "5px")
     .style("padding", "5px")
+    .style("position", "absolute")
 
   // Three function that change the tooltip when user hover / move / leave a cell
   const mouseover = function(event,d) {

--- a/graph/histogram_tooltip.html
+++ b/graph/histogram_tooltip.html
@@ -310,6 +310,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
     .style("color", "white")
     .style("border-radius", "5px")
     .style("padding", "10px")
+    .style("position", "absolute")
 
   // A function that change this tooltip when the user hover a point.
   // Its opacity is set to 1: we can now see it. Plus it set the text and position of tooltip depending on the datapoint (d)
@@ -411,6 +412,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
     .style("color", "white")
     .style("border-radius", "5px")
     .style("padding", "10px")
+    .style("position", "absolute")
 
   // A function that change this tooltip when the user hover a point.
   // Its opacity is set to 1: we can now see it. Plus it set the text and position of tooltip depending on the datapoint (d)

--- a/graph/interactivity_tooltip.html
+++ b/graph/interactivity_tooltip.html
@@ -610,6 +610,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/he
     .style("border-width", "2px")
     .style("border-radius", "5px")
     .style("padding", "5px")
+    .style("position", "absolute")
 
   // Three function that change the tooltip when user hover / move / leave a cell
   var mouseover = function(d) {

--- a/graph/scatter_tooltip.html
+++ b/graph/scatter_tooltip.html
@@ -302,6 +302,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
     .style("border-width", "1px")
     .style("border-radius", "5px")
     .style("padding", "10px")
+    .style("position", "absolute")
 
 
 
@@ -396,6 +397,7 @@ d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_data
     .style("border-width", "1px")
     .style("border-radius", "5px")
     .style("padding", "10px")
+    .style("position", "absolute")
 
 
 


### PR DESCRIPTION
the code in the examples is missing this style for the tooltip, so it doesn't work as-is when copied

https://www.reddit.com/r/d3js/comments/1azxo4y/scatterplot_tooltip_not_working_correctly/

the version hosted on the graph gallery website happens to work because the `position: absolute` style for `.tooltip` is added by bootstrap, but running the code on a page without bootstrap won't work

