### PR TITLE
Fix repeated creation of axes in loop

### DIFF
--- a/graph/scatter_basic.html
+++ b/graph/scatter_basic.html
@@ -287,23 +287,23 @@ var svg = d3.select("#my_dataviz")
     .attr("transform",
           "translate(" + margin.left + "," + margin.top + ")");
 
+// Add X axis
+var x = d3.scaleLinear()
+  .domain([0, 4000])
+  .range([ 0, width ]);
+svg.append("g")
+  .attr("transform", "translate(0," + height + ")")
+  .call(d3.axisBottom(x));
+
+// Add Y axis
+var y = d3.scaleLinear()
+  .domain([0, 500000])
+  .range([ height, 0]);
+svg.append("g")
+  .call(d3.axisLeft(y));
+
 //Read the data
 d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_dataset/2_TwoNum.csv", function(data) {
-
-  // Add X axis
-  var x = d3.scaleLinear()
-    .domain([0, 4000])
-    .range([ 0, width ]);
-  svg.append("g")
-    .attr("transform", "translate(0," + height + ")")
-    .call(d3.axisBottom(x));
-
-  // Add Y axis
-  var y = d3.scaleLinear()
-    .domain([0, 500000])
-    .range([ height, 0]);
-  svg.append("g")
-    .call(d3.axisLeft(y));
 
   // Add dots
   svg.append('g')
@@ -339,23 +339,23 @@ const svg = d3.select("#my_dataviz")
     .append("g")
     .attr("transform", `translate(${margin.left}, ${margin.top})`);
 
-//Read the data
-d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_dataset/2_TwoNum.csv").then( function(data) {
-
-    // Add X axis
-    const x = d3.scaleLinear()
+// Add X axis
+const x = d3.scaleLinear()
     .domain([0, 4000])
     .range([ 0, width ]);
-    svg.append("g")
+svg.append("g")
     .attr("transform", `translate(0, ${height})`)
     .call(d3.axisBottom(x));
 
-    // Add Y axis
-    const y = d3.scaleLinear()
+// Add Y axis
+const y = d3.scaleLinear()
     .domain([0, 500000])
     .range([ height, 0]);
-    svg.append("g")
+svg.append("g")
     .call(d3.axisLeft(y));
+
+//Read the data
+d3.csv("https://raw.githubusercontent.com/holtzy/data_to_viz/master/Example_dataset/2_TwoNum.csv").then( function(data) {
 
     // Add dots
     svg.append('g')


### PR DESCRIPTION
The previous code in this example creates x- and y-axis repeatedly. Once per row in the CSV file. That results in thousands of SVG elements for the axes, ticks, etc.

As given the previous code does not plot any nodes in the scatter plot for me.

This commit moves creation of axes out of the loop. Now, the resulting SVG visualization looks as the one given on this HTML page.